### PR TITLE
correct mistaken reference to cf2021 image

### DIFF
--- a/cf-latest/compose.yaml
+++ b/cf-latest/compose.yaml
@@ -1,6 +1,6 @@
 services:
     coldfusion: 
-        image: adobecoldfusion/coldfusion2021:latest
+        image: adobecoldfusion/coldfusion:latest
         ports:
         - "8500:8500"
         environment:


### PR DESCRIPTION
Since this example's folder is named cf-latest, the image should indeed be Adobe's image which has no version in its name